### PR TITLE
#11-解析設定ファイルに対するバリデーションチェックの実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,12 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,7 +225,6 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "naifuru"
 version = "0.1.0-alpha"
 dependencies = [
- "anyhow",
  "clap",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ toml = "0.8.19"
 log = "0.4.22"
 thiserror = "2.0.7"
 env_logger = "0.11.5"
-anyhow = "1.0.94"
 
 [profile.dev]
 opt-level = 0

--- a/src/analysis_config_file.rs
+++ b/src/analysis_config_file.rs
@@ -1,14 +1,8 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::error::{ErrorContext, Module};
-
-const ERROR_MODULE: Module = Module::ConfigFileAnalysis;
+use crate::error::IoErrWrapper;
 
 /// File format before conversion.  
 #[derive(Debug, Serialize, Deserialize)]
@@ -81,9 +75,8 @@ pub struct FileConfig {
     pub acc_axis: Option<AccAxis>,
 }
 
-pub fn read_config_from_input_file(input_file_path: &Path) -> Result<String> {
-    fs::read_to_string(input_file_path).with_context(|| ErrorContext {
-        message: format!("Failed to read config file: {}", input_file_path.display()),
-        module: ERROR_MODULE,
-    })
+pub fn read_config_from_input_file(input_file_path: &Path) -> Result<String, IoErrWrapper> {
+    let config: String = std::fs::read_to_string(input_file_path)?;
+
+    Ok(config)
 }

--- a/src/analysis_config_file.rs
+++ b/src/analysis_config_file.rs
@@ -78,15 +78,15 @@ pub struct Group {
 
 impl Group {
     pub fn valid_path_in_group(&self) -> Result<()> {
-        todo!()
+        Ok(())
     }
 
     pub fn valid_direction_component(&self) -> Result<()> {
-        todo!()
+        Ok(())
     }
 
     pub fn valid_group_key(&self) -> Result<()> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -116,10 +116,6 @@ impl GlobalConfig {
 pub struct GlobalSettings {
     /// output file name format.
     name_format: NameFormat,
-    /// acceleration calculate option bool.
-    acc_calculate: bool,
-    /// unit conversion option bool.
-    unit_conversion: bool,
 }
 
 impl GlobalSettings {

--- a/src/analysis_config_file.rs
+++ b/src/analysis_config_file.rs
@@ -1,11 +1,17 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    fmt::Write,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AnalysisConfigErr, AppError, ConfigValidationErr, IoErrWrapper};
 
+const MULTIPLE_AXIS_TYPE: [&From; 2] = [&From::JpNiedKnet, &From::TkAfadAsc];
+
 /// File format before conversion.  
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum From {
     JpNiedKnet,
@@ -16,8 +22,21 @@ pub enum From {
     TkAfadAsc,
 }
 
+impl From {
+    fn to_snake_case(&self) -> &str {
+        match self {
+            From::JpNiedKnet => "jp_nied_knet",
+            From::UsScsnV2 => "us_scsn_v2",
+            From::NzGeonetV1a => "nz_geonet_v1a",
+            From::NzGeonetV2a => "nz_geonet_v2a",
+            From::TwPalertSac => "tw_palert_sac",
+            From::TkAfadAsc => "tk_afad_asc",
+        }
+    }
+}
+
 /// File format after conversion.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum To {
     JpJmaCsv,
@@ -25,7 +44,7 @@ pub enum To {
 }
 
 /// File format before conversion.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AccAxis {
     Ns,
@@ -33,7 +52,17 @@ pub enum AccAxis {
     Ud,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl AccAxis {
+    fn as_str(&self) -> &str {
+        match self {
+            AccAxis::Ns => "ns",
+            AccAxis::Ew => "ew",
+            AccAxis::Ud => "ud",
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum NameFormat {
     /// ## **Example: 20240101-161018-ISK005-knet.csv.**
@@ -44,7 +73,7 @@ pub enum NameFormat {
     YyyymmddHhmmssSnN,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
     pub global: GlobalConfig,
     pub conversion: Vec<ConversionConfig>,
@@ -53,12 +82,18 @@ pub struct Config {
 impl Config {
     pub fn validate(&self) -> Result<(), Vec<AppError>> {
         let mut errors: Vec<AppError> = Vec::new();
+        let mut all_names: Vec<String> = Vec::new();
 
         for conv_config in &self.conversion {
             let _ = conv_config.validate().map_err(|e| {
                 errors.extend(e.into_iter().map(AppError::from));
             });
+            all_names.push(conv_config.name.to_string());
         }
+
+        let _ = self.validate_duplicate_name(all_names).map_err(|e| {
+            errors.push(e.into());
+        });
 
         if !errors.is_empty() {
             return Err(errors);
@@ -66,16 +101,32 @@ impl Config {
 
         Ok(())
     }
+
+    fn validate_duplicate_name(&self, all_names: Vec<String>) -> Result<(), AnalysisConfigErr> {
+        let mut duplicate_name_set = HashSet::new();
+
+        for name in all_names {
+            if !duplicate_name_set.insert(name) {
+                return Err(ConfigValidationErr::DuplicateNames(hashset_to_string(
+                    &duplicate_name_set,
+                ))
+                .into());
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // MEMO: 列挙型はtomlによってバリデーションが行われるため、この構造体でバリデーション実装は行いません。
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GlobalConfig {
     pub name_format: NameFormat,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConversionConfig {
+    pub name: String,
     pub from: From,
     pub to: To,
     pub group: Vec<GroupConfig>,
@@ -85,11 +136,14 @@ impl ConversionConfig {
     pub fn validate(&self) -> Result<(), Vec<AnalysisConfigErr>> {
         let mut errors: Vec<AnalysisConfigErr> = Vec::new();
 
-        for group_config in &self.group {
+        for (g_index, group_config) in self.group.iter().enumerate() {
+            let id: usize = g_index + 1;
             let acceptable_exts: &[&str] = Self::assign_ext_based_on_from(&self.from);
-            let _ = group_config.validate(acceptable_exts).map_err(|e| {
-                errors.extend(e.into_iter().map(AnalysisConfigErr::from));
-            });
+            let _ = group_config
+                .validate(&self.from, acceptable_exts, &self.name, id)
+                .map_err(|e| {
+                    errors.extend(e.into_iter().map(AnalysisConfigErr::from));
+                });
         }
 
         if !errors.is_empty() {
@@ -99,6 +153,7 @@ impl ConversionConfig {
         Ok(())
     }
 
+    // 加速度の方向成分が別々のファイルで指定されているタイプのファイル
     fn assign_ext_based_on_from(from: &From) -> &[&str] {
         match from {
             From::JpNiedKnet => &["ns", "ew", "ud"],
@@ -111,19 +166,81 @@ impl ConversionConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GroupConfig {
     pub files: Vec<FileConfig>,
 }
 
 impl GroupConfig {
-    pub fn validate(&self, acceptable_exts: &[&str]) -> Result<(), Vec<AnalysisConfigErr>> {
+    pub fn validate(
+        &self,
+        from: &From,
+        acceptable_exts: &[&str],
+        name: &str,
+        id: usize,
+    ) -> Result<(), Vec<AnalysisConfigErr>> {
         let mut errors: Vec<AnalysisConfigErr> = Vec::new();
 
         for file in &self.files {
             let _ = file.validate(acceptable_exts).map_err(|e| {
                 errors.extend(e.into_iter().map(AnalysisConfigErr::from));
             });
+        }
+
+        self.validate_file_by_acc_axis(from, name, id)?;
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(())
+    }
+
+    fn validate_file_by_acc_axis(
+        &self,
+        from: &From,
+        name: &str,
+        id: usize,
+    ) -> Result<(), Vec<AnalysisConfigErr>> {
+        let mut errors: Vec<AnalysisConfigErr> = Vec::new();
+
+        // 各成分が別のファイルで管理されている形式の場合はNS,EW,UDの3つが必要
+        if MULTIPLE_AXIS_TYPE.contains(&from) {
+            let mut required_axis = vec!["ns", "ew", "ud"];
+            for file in &self.files {
+                // acc_axisが存在するか
+                if let Some(acc_axis) = &file.acc_axis {
+                    // 一致する要素が存在するか
+                    if let Some(pos) = required_axis.iter().position(|&x| x == acc_axis.as_str()) {
+                        required_axis.remove(pos);
+                    } else {
+                        errors.push(
+                            ConfigValidationErr::DuplicateAccAxis(
+                                from.to_snake_case().to_string(),
+                                name.to_string(),
+                                id,
+                            )
+                            .into(),
+                        );
+                    }
+                } else {
+                    errors.push(ConfigValidationErr::RequiredAccAxis(name.to_string(), id).into());
+                }
+            }
+        // 全ての成分が単一ファイル内で管理されている形式
+        } else {
+            for file in &self.files {
+                if !&file.acc_axis.is_none() {
+                    errors.push(
+                        ConfigValidationErr::MismatchedAccAxis(
+                            from.to_snake_case().to_string(),
+                            name.to_string(),
+                            id,
+                        )
+                        .into(),
+                    );
+                }
+            }
         }
 
         if !errors.is_empty() {
@@ -134,7 +251,7 @@ impl GroupConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileConfig {
     pub path: PathBuf,
     pub acc_axis: Option<AccAxis>,
@@ -199,4 +316,12 @@ pub fn read_config_from_input_file(input_file_path: &Path) -> Result<String, IoE
     let config: String = std::fs::read_to_string(input_file_path)?;
 
     Ok(config)
+}
+
+fn hashset_to_string(set: &HashSet<String>) -> String {
+    let mut result = String::new();
+    for item in set {
+        writeln!(&mut result, "{}", item).unwrap();
+    }
+    result
 }

--- a/src/analysis_config_file.rs
+++ b/src/analysis_config_file.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::IoErrWrapper;
+use crate::error::{AnalysisConfigErr, AppError, ConfigValidationErr, IoErrWrapper};
 
 /// File format before conversion.  
 #[derive(Debug, Serialize, Deserialize)]
@@ -50,6 +50,25 @@ pub struct Config {
     pub conversion: Vec<ConversionConfig>,
 }
 
+impl Config {
+    pub fn validate(&self) -> Result<(), Vec<AppError>> {
+        let mut errors: Vec<AppError> = Vec::new();
+
+        for conv_config in &self.conversion {
+            let _ = conv_config.validate().map_err(|e| {
+                errors.extend(e.into_iter().map(AppError::from));
+            });
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(())
+    }
+}
+
+// MEMO: 列挙型はtomlによってバリデーションが行われるため、この構造体でバリデーション実装は行いません。
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GlobalConfig {
     pub name_format: NameFormat,
@@ -57,22 +76,123 @@ pub struct GlobalConfig {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConversionConfig {
-    pub id: u16,
     pub from: From,
     pub to: To,
     pub group: Vec<GroupConfig>,
 }
 
+impl ConversionConfig {
+    pub fn validate(&self) -> Result<(), Vec<AnalysisConfigErr>> {
+        let mut errors: Vec<AnalysisConfigErr> = Vec::new();
+
+        for group_config in &self.group {
+            let acceptable_exts: &[&str] = Self::assign_ext_based_on_from(&self.from);
+            let _ = group_config.validate(acceptable_exts).map_err(|e| {
+                errors.extend(e.into_iter().map(AnalysisConfigErr::from));
+            });
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(())
+    }
+
+    fn assign_ext_based_on_from(from: &From) -> &[&str] {
+        match from {
+            From::JpNiedKnet => &["ns", "ew", "ud"],
+            From::UsScsnV2 => &["v2"],
+            From::NzGeonetV1a => &["v1a"],
+            From::NzGeonetV2a => &["v2a"],
+            From::TwPalertSac => &["sac"],
+            From::TkAfadAsc => &["asc"],
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GroupConfig {
-    pub id: u16,
     pub files: Vec<FileConfig>,
+}
+
+impl GroupConfig {
+    pub fn validate(&self, acceptable_exts: &[&str]) -> Result<(), Vec<AnalysisConfigErr>> {
+        let mut errors: Vec<AnalysisConfigErr> = Vec::new();
+
+        for file in &self.files {
+            let _ = file.validate(acceptable_exts).map_err(|e| {
+                errors.extend(e.into_iter().map(AnalysisConfigErr::from));
+            });
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FileConfig {
     pub path: PathBuf,
     pub acc_axis: Option<AccAxis>,
+}
+
+impl FileConfig {
+    pub fn validate(&self, acceptable_exts: &[&str]) -> Result<(), Vec<AnalysisConfigErr>> {
+        let mut errors: Vec<AnalysisConfigErr> = Vec::new();
+
+        let _ = self
+            .validate_extension_for_acceptable_exts(acceptable_exts)
+            .map_err(|e| {
+                errors.push(e);
+            });
+
+        let _ = self.validate_path().map_err(|e| {
+            errors.push(e);
+        });
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(())
+    }
+
+    fn validate_path(&self) -> Result<(), AnalysisConfigErr> {
+        if !self.path.exists() {
+            return Err(ConfigValidationErr::PathDoesNotExist(self.path.to_path_buf()).into());
+        } else if !self.path.is_file() {
+            return Err(ConfigValidationErr::PathIsNotFile(self.path.to_path_buf()).into());
+        }
+
+        Ok(())
+    }
+
+    fn validate_extension_for_acceptable_exts(
+        &self,
+        acceptable_exts: &[&str],
+    ) -> Result<(), AnalysisConfigErr> {
+        if let Some(extension) = self
+            .path
+            .extension()
+            .map(|ext| ext.to_string_lossy().to_lowercase())
+        {
+            if !acceptable_exts.contains(&extension.as_str()) {
+                return Err(ConfigValidationErr::InvalidExtension(
+                    acceptable_exts.join(", "),
+                    extension,
+                )
+                .into());
+            }
+        } else {
+            return Err(ConfigValidationErr::NoExtension(self.path.to_path_buf()).into());
+        }
+
+        Ok(())
+    }
 }
 
 pub fn read_config_from_input_file(input_file_path: &Path) -> Result<String, IoErrWrapper> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,8 @@ use crate::{
     logging::LogLevel,
 };
 
+const ACCEPTABLE_EXTS: [&str; 1] = ["toml"];
+
 /// This module defines the command-line interface (CLI) for the application using the `clap` crate.
 /// It includes the `Args` struct which represents the parsed command-line arguments and provides
 /// methods for validation of these arguments.
@@ -70,15 +72,14 @@ impl Args {
 
     fn validate_input_file_path(&self, path: &Path) -> Result<(), Vec<CliErr>> {
         let mut errors: Vec<CliErr> = Vec::new();
-        let valid_extensions: [&str; 1] = ["toml"];
 
         if let Some(extension) = path
             .extension()
             .map(|ext| ext.to_string_lossy().to_lowercase())
         {
-            if !valid_extensions.contains(&extension.as_str()) {
+            if !ACCEPTABLE_EXTS.contains(&extension.as_str()) {
                 errors.push(
-                    ArgsValidationErr::InvalidExtension(extension, valid_extensions.join(", "))
+                    ArgsValidationErr::InvalidExtension(extension, ACCEPTABLE_EXTS.join(", "))
                         .into(),
                 );
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, ValueHint};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,7 +191,7 @@ mod tests {
 
             if ext.is_empty() {
                 assert!(
-                    errors.contains(&CliErr::ArgsValidation(ArgsValidationErr::NoExtension(
+                    errors.contains(&CliErr::Validation(ArgsValidationErr::NoExtension(
                         file_path
                     ))),
                     "Expected 'NoExtension' error, got: {:?}",
@@ -199,9 +199,10 @@ mod tests {
                 );
             } else {
                 assert!(
-                    errors.contains(&CliErr::ArgsValidation(
-                        ArgsValidationErr::InvalidExtension(ext.to_string(), "toml".to_string())
-                    )),
+                    errors.contains(&CliErr::Validation(ArgsValidationErr::InvalidExtension(
+                        ext.to_string(),
+                        "toml".to_string()
+                    ))),
                     "Expected 'InvalidExtension' error, got: {:?}",
                     errors
                 );
@@ -224,9 +225,9 @@ mod tests {
         let errors = result.unwrap_err();
 
         assert!(
-            errors.contains(&CliErr::ArgsValidation(
-                ArgsValidationErr::PathDoesNotExist(non_existent_file_path.to_path_buf())
-            )),
+            errors.contains(&CliErr::Validation(ArgsValidationErr::PathDoesNotExist(
+                non_existent_file_path.to_path_buf()
+            ))),
             "Expected 'PathDoesNotExist' error, got: {:?}",
             errors
         );
@@ -246,7 +247,7 @@ mod tests {
         let errors = result.unwrap_err();
 
         assert!(
-            errors.contains(&CliErr::ArgsValidation(ArgsValidationErr::PathIsNotFile(
+            errors.contains(&CliErr::Validation(ArgsValidationErr::PathIsNotFile(
                 dir.path().display().to_string().into()
             ))),
             "Expected 'PathIsNotFile' error, got: {:?}",
@@ -282,9 +283,9 @@ mod tests {
         let errors = result.unwrap_err();
 
         assert!(
-            errors.contains(&CliErr::ArgsValidation(
-                ArgsValidationErr::PathDoesNotExist(non_existent_dir.to_path_buf())
-            )),
+            errors.contains(&CliErr::Validation(ArgsValidationErr::PathDoesNotExist(
+                non_existent_dir.to_path_buf()
+            ))),
             "Expected 'PathDoesNotExist' error, got: {:?}",
             errors
         );
@@ -308,9 +309,9 @@ mod tests {
         let errors = result.unwrap_err();
 
         assert!(
-            errors.contains(&CliErr::ArgsValidation(
-                ArgsValidationErr::PathIsNotDirectory(file_path.to_path_buf())
-            )),
+            errors.contains(&CliErr::Validation(ArgsValidationErr::PathIsNotDirectory(
+                file_path.to_path_buf()
+            ))),
             "Expected 'PathIsNotDirectory' error, got: {:?}",
             errors
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,11 +20,28 @@ pub enum AppError {
     AnalysisConfig(#[from] AnalysisConfigErr),
 }
 
+impl AppError {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            AppError::Cli(e) => e.exit_code(),
+            AppError::AnalysisConfig(e) => e.exit_code(),
+        }
+    }
+}
+
 #[non_exhaustive]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum CliErr {
     #[error("Args validation error> {0}")]
     Validation(#[from] ArgsValidationErr),
+}
+
+impl CliErr {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            CliErr::Validation(_) => 2,
+        }
+    }
 }
 
 #[non_exhaustive]
@@ -36,6 +53,16 @@ pub enum AnalysisConfigErr {
     Parse(#[from] toml::de::Error),
     #[error("I/O error> {0}")]
     Io(#[from] IoErrWrapper),
+}
+
+impl AnalysisConfigErr {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            AnalysisConfigErr::Validation(_) => 3,
+            AnalysisConfigErr::Parse(_) => 5,
+            AnalysisConfigErr::Io(_) => 4,
+        }
+    }
 }
 
 #[non_exhaustive]

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,14 @@ pub enum ArgsValidationErr {
 pub enum ConfigValidationErr {
     #[error("{0} axis component file is missing in group id: {1}")]
     AccAxisDoesNotExist(String, u16),
+    #[error("The extension is {0} even though the possible extensions for this From are {1}")]
+    InvalidExtension(String, String),
+    #[error("File has no extension: {0}")]
+    NoExtension(PathBuf),
+    #[error("Path does not exist: {0}")]
+    PathDoesNotExist(PathBuf),
+    #[error("Path is not a file: {0}")]
+    PathIsNotFile(PathBuf),
 }
 
 // PartialEq, Eqの実装を行うための、std::io::ErrorをラップするカスタムI/Oエラー型

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /// This module defines custom error types and utilities for handling errors in the application.
-use std::{fmt, path::PathBuf};
+use std::path::PathBuf;
 
 use thiserror::Error;
 
@@ -16,14 +16,26 @@ macro_rules! bail_on_error {
 pub enum AppError {
     #[error("CLI error> {0}")]
     Cli(#[from] CliErr),
-    // TODO: AnalysisConfigErr
+    #[error("AnalysisConfig error> {0}")]
+    AnalysisConfig(#[from] AnalysisConfigErr),
 }
 
 #[non_exhaustive]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum CliErr {
     #[error("Args validation error> {0}")]
-    ArgsValidation(#[from] ArgsValidationErr),
+    Validation(#[from] ArgsValidationErr),
+}
+
+#[non_exhaustive]
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum AnalysisConfigErr {
+    #[error("Analysis config validation error> {0}")]
+    Validation(#[from] ConfigValidationErr),
+    #[error("Analysis config parse error> {0}")]
+    Parse(#[from] toml::de::Error),
+    #[error("I/O error> {0}")]
+    Io(#[from] IoErrWrapper),
 }
 
 #[non_exhaustive]
@@ -39,6 +51,13 @@ pub enum ArgsValidationErr {
     PathIsNotFile(PathBuf),
     #[error("Path is not a directory: {0}")]
     PathIsNotDirectory(PathBuf),
+}
+
+#[non_exhaustive]
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ConfigValidationErr {
+    #[error("{0} axis component file is missing in group id: {1}")]
+    AccAxisDoesNotExist(String, u16),
 }
 
 // PartialEq, Eqの実装を行うための、std::io::ErrorをラップするカスタムI/Oエラー型

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,31 +68,39 @@ impl AnalysisConfigErr {
 #[non_exhaustive]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ArgsValidationErr {
-    #[error("File has no extension: {0}")]
+    #[error("File has no extension: '{0}'")]
     NoExtension(PathBuf),
-    #[error("Invalid file extension: {0}, expected one of: {1}")]
+    #[error("Invalid file extension: '{0}', expected one of: '{1}'")]
     InvalidExtension(String, String),
-    #[error("Path does not exist: {0}")]
+    #[error("Path does not exist: '{0}'")]
     PathDoesNotExist(PathBuf),
-    #[error("Path is not a file: {0}")]
+    #[error("Path is not a file: '{0}'")]
     PathIsNotFile(PathBuf),
-    #[error("Path is not a directory: {0}")]
+    #[error("Path is not a directory: '{0}'")]
     PathIsNotDirectory(PathBuf),
 }
 
 #[non_exhaustive]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ConfigValidationErr {
-    #[error("{0} axis component file is missing in group id: {1}")]
-    AccAxisDoesNotExist(String, u16),
-    #[error("The extension is {0} even though the possible extensions for this From are {1}")]
+    #[error("The extension is {0} even though the possible extensions for this From are '{1}'")]
     InvalidExtension(String, String),
-    #[error("File has no extension: {0}")]
+    #[error("File has no extension: '{0}'")]
     NoExtension(PathBuf),
-    #[error("Path does not exist: {0}")]
+    #[error("Path does not exist: '{0}'")]
     PathDoesNotExist(PathBuf),
-    #[error("Path is not a file: {0}")]
+    #[error("Path is not a file: '{0}'")]
     PathIsNotFile(PathBuf),
+    #[error("'{0}' does not require acc_axis but was set: name:'{1}', id:'{2}'")]
+    MismatchedAccAxis(String, String, usize),
+    #[error(
+        "'{0}' format requires acc_axis to be 'ns, ew, ud' but was not set: name:'{1}', id:'{2}'"
+    )]
+    DuplicateAccAxis(String, String, usize),
+    #[error("acc_axis does not exist: name:'{0}', id:'{1}'")]
+    RequiredAccAxis(String, usize),
+    #[error("Duplicate names, each NAME must be unique: '{0}'")]
+    DuplicateNames(String),
 }
 
 // PartialEq, Eqの実装を行うための、std::io::ErrorをラップするカスタムI/Oエラー型

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 /// This module defines custom error types and utilities for handling errors in the application.
-use std::fmt;
+use std::{fmt, path::PathBuf};
+
+use thiserror::Error;
 
 #[macro_export]
 macro_rules! bail_on_error {
@@ -8,29 +10,62 @@ macro_rules! bail_on_error {
     }};
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Module {
-    CliArgsValidation,
-    ConfigFileAnalysis,
+// トップレベルカスタムエラー
+#[non_exhaustive]
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum AppError {
+    #[error("CLI error> {0}")]
+    Cli(#[from] CliErr),
+    // TODO: AnalysisConfigErr
 }
 
-impl Module {
-    pub fn exit_code(&self) -> i32 {
-        match self {
-            Module::CliArgsValidation => 2,
-            Module::ConfigFileAnalysis => 78, // EX_CONFIG
-        }
-    }
+#[non_exhaustive]
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum CliErr {
+    #[error("Args validation error> {0}")]
+    ArgsValidation(#[from] ArgsValidationErr),
 }
 
+#[non_exhaustive]
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ArgsValidationErr {
+    #[error("File has no extension: {0}")]
+    NoExtension(PathBuf),
+    #[error("Invalid file extension: {0}, expected one of: {1}")]
+    InvalidExtension(String, String),
+    #[error("Path does not exist: {0}")]
+    PathDoesNotExist(PathBuf),
+    #[error("Path is not a file: {0}")]
+    PathIsNotFile(PathBuf),
+    #[error("Path is not a directory: {0}")]
+    PathIsNotDirectory(PathBuf),
+}
+
+// PartialEq, Eqの実装を行うための、std::io::ErrorをラップするカスタムI/Oエラー型
 #[derive(Debug)]
-pub struct ErrorContext {
-    pub message: String,
-    pub module: Module,
-}
+pub struct IoErrWrapper(pub std::io::Error);
 
-impl fmt::Display for ErrorContext {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
+impl From<std::io::Error> for IoErrWrapper {
+    fn from(err: std::io::Error) -> Self {
+        IoErrWrapper(err)
     }
 }
+
+// IoErrWrapperにPartialEqを実装
+impl PartialEq for IoErrWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.kind() == other.0.kind() && self.0.to_string() == other.0.to_string()
+    }
+}
+
+// IoErrWrapperにEqを実装
+impl Eq for IoErrWrapper {}
+
+impl std::fmt::Display for IoErrWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "I/O error> {}", self.0)
+    }
+}
+
+// IoErrWrapperにErrorトレイトを実装（エラーをそのまま扱えるようにする）
+impl std::error::Error for IoErrWrapper {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,49 +1,48 @@
-use std::fs;
-
-use anyhow::{Context, Result};
 use log::{debug, error};
 use naifuru::{
-    analysis_config_file::Config, bail_on_error, cli::Args, error::ErrorContext,
+    analysis_config_file::{read_config_from_input_file, Config},
+    bail_on_error,
+    cli::Args,
+    error::AppError,
     logging::init_logger,
 };
 
 const DEFAULT_ERROR_EXIT_CODE: i32 = 1;
 
 fn main() {
-    if let Err(e) = run() {
-        error!("{e:?}");
-
-        if let Some(error_context) = e.downcast_ref::<ErrorContext>() {
-            bail_on_error!(error_context.module.exit_code());
+    if let Err(errors) = run() {
+        for error in &errors {
+            error!("{}", error);
         }
 
-        // ErrorContext を取得できない場合は、デフォルトのエラー コード 1 で終了します。
-        bail_on_error!(DEFAULT_ERROR_EXIT_CODE);
+        // 最初のエラーからexit_codeを決定、また、exit_codeを取得できない場合はDEFAULT_ERROR_EXIT_CODEで終了します。
+        let exit_code = errors
+            .first()
+            .map_or(DEFAULT_ERROR_EXIT_CODE, |e| e.exit_code());
+
+        bail_on_error!(exit_code);
     }
 }
 
-fn run() -> Result<()> {
+fn run() -> Result<(), Vec<AppError>> {
     let args = Args::new();
 
-    init_logger(args.log_level.into())?;
+    // TODO: 非推奨: unwrap()
+    init_logger(args.log_level.into()).unwrap();
     debug!("The loglevel has been set.");
 
     args.validate()?;
-    debug!("Validation check completed.");
+    debug!("Cli args validation check completed.");
 
-    let config_toml_str = fs::read_to_string(&args.input_file_path).with_context(|| {
-        format!(
-            "Failed to read config file: {}",
-            args.input_file_path.display()
-        )
-    })?;
+    let config_toml_str = read_config_from_input_file(&args.input_file_path)
+        .map_err(|e| vec![AppError::AnalysisConfig(e.into())])?;
     debug!("Analysis configuration file loading is complete.");
 
     let config: Config =
-        toml::from_str(&config_toml_str).with_context(|| "Failed to parse TOML configuration")?;
+        toml::from_str(&config_toml_str).map_err(|e| vec![AppError::AnalysisConfig(e.into())])?;
     debug!("Analysis configuration file parsing is complete.");
 
-    print!("{config:#?}");
+    println!("{config:#?}");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,22 +27,22 @@ fn main() {
 fn run() -> Result<(), Vec<AppError>> {
     let args = Args::new();
 
-    // TODO: 非推奨: unwrap()
     init_logger(args.log_level.into()).unwrap();
-    debug!("The loglevel has been set.");
+    debug!("The logging level has been set successfully.");
 
     args.validate()?;
-    debug!("Cli args validation check completed.");
+    debug!("The CLI args have been validated successfully.");
 
     let config_toml_str = read_config_from_input_file(&args.input_file_path)
         .map_err(|e| vec![AppError::AnalysisConfig(e.into())])?;
-    debug!("Analysis configuration file loading is complete.");
+    debug!("The analysis configuration file has been loaded successfully.");
 
     let config: Config =
         toml::from_str(&config_toml_str).map_err(|e| vec![AppError::AnalysisConfig(e.into())])?;
-    debug!("Analysis configuration file parsing is complete.");
+    debug!("The analysis configuration file has been parsed successfully.");
 
-    println!("{config:#?}");
+    config.validate()?;
+    debug!("The analysis configuration file has been validated successfully.");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
             bail_on_error!(error_context.module.exit_code());
         }
 
-        // If ErrorContext cannot be obtained, exit with default error code 1
+        // ErrorContext を取得できない場合は、デフォルトのエラー コード 1 で終了します。
         bail_on_error!(DEFAULT_ERROR_EXIT_CODE);
     }
 }


### PR DESCRIPTION
## 概要
解析設定に使用するtomlファイルのバリデーションチェックの実装

## 変更点
- Anyhowを削除し、tomlでのエラー定義に変更。
- Anyhowの廃止に伴うCliバリデーションのエラーハンドリングの変更
- Config構造体を最上位構造体とする、階層型のtomlファイル構造体に対するバリデーションチェックの実装と、純粋関数の追加

## テスト

## 関連するissue
Closed #11 

## 追加情報


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Changes**
	- Removed `anyhow` dependency from project configuration

- **Error Handling Improvements**
	- Enhanced error reporting with more detailed and comprehensive error types
	- Introduced ability to collect and report multiple errors simultaneously
	- Implemented more specific error categorization for CLI and configuration validation

- **Configuration Validation**
	- Added robust validation methods for configuration files
	- Improved error checking for input files and configuration settings

- **Code Structure**
	- Refactored error handling approach
	- Updated function signatures to support more comprehensive error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->