### PR TITLE
[Bugfix] #18-エラーコンテキストとして渡すフィールド値の順序の修正

### DIFF
--- a/src/analysis_config_file.rs
+++ b/src/analysis_config_file.rs
@@ -299,8 +299,8 @@ impl FileConfig {
         {
             if !acceptable_exts.contains(&extension.as_str()) {
                 return Err(ConfigValidationErr::InvalidExtension(
-                    acceptable_exts.join(", "),
                     extension,
+                    acceptable_exts.join(", "),
                 )
                 .into());
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,7 @@ pub enum ArgsValidationErr {
 #[non_exhaustive]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ConfigValidationErr {
-    #[error("The extension is {0} even though the possible extensions for this From are '{1}'")]
+    #[error("The extension is '{0}' even though the possible extensions for this From are '{1}'")]
     InvalidExtension(String, String),
     #[error("File has no extension: '{0}'")]
     NoExtension(PathBuf),


### PR DESCRIPTION
## 変更点
- validate_extension_for_acceptable_extsメソッドエラーを返す部分での、InvalidExtensionに渡すフィールド値の順序が間違っていた。
**修正前**
```Rust
return Err(ConfigValidationErr::InvalidExtension(
                    acceptable_exts.join(", "),
                    extension,
                )
```

**修正後**
```Rust
return Err(ConfigValidationErr::InvalidExtension(
                    extension,
                    acceptable_exts.join(", "),
                )
```

- The extension is '{0}'の部分のシングルクオーテーションが不足していた。
**エラー定義**
```Rust
pub enum ConfigValidationErr {
    #[error("The extension is '{0}' even though the possible extensions for this From are '{1}'")]
    InvalidExtension(String, String),
}
```

## 関連するissue
- #15
Closed #18 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message formatting for file extension validation
  - Enhanced clarity of error messages when file extensions do not match expected formats

The changes focus on refining error message presentation to provide more precise and readable feedback during configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->